### PR TITLE
Check what wld.renderer is not null

### DIFF
--- a/src/wterm.c
+++ b/src/wterm.c
@@ -2953,7 +2953,7 @@ void wlinit(void) {
   if (!wld.ctx)
     die("Can't create wayland context\n");
   wld.renderer = wld_create_renderer(wld.ctx);
-  if (!wld.ctx)
+  if (!wld.ctx || !wld.renderer)
     die("Can't create renderer\n");
   if (!wl.shm)
     die("Display has no SHM\n");


### PR DESCRIPTION
It would segfault for me, turns out wld.renderer is null, not entirely
sure why yet but add a check for that so it'll exit instead of
segfaulting.

Note that using perror() instead of just exiting gives at least *some*
info as to what's going wrong:

	Can't create renderer: Permission denied

So maybe add that to die()? But that's a larger change so didn't add
that here.